### PR TITLE
Update naming and links to awesome assertions

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -5,15 +5,15 @@ body:
   - type: markdown
     attributes:
       value: |
-        We welcome bug reports! Please see our [contribution guidelines](https://github.com/fluentassertions/fluentassertions/blob/develop/CONTRIBUTING.md#writing-a-good-bug-report) for more information on writing a good bug report.
+        We welcome bug reports! Please see our [contribution guidelines](https://github.com/AwesomeAssertions/AwesomeAssertions.DataSets/blob/main/CONTRIBUTING.md#writing-a-good-bug-report) for more information on writing a good bug report.
         
         **Before continuing, have you:**
 
-          * Tried upgrading to newest version of Fluent Assertions, to see if your issue has already been resolved and released?
-          * Checked existing open *and* closed [issues](https://github.com/fluentassertions/fluentassertions/issues?utf8=%E2%9C%93&q=is%3Aissue), to see if the issue has already been reported?
+          * Tried upgrading to newest version of Awesome Assertions, to see if your issue has already been resolved and released?
+          * Checked existing open *and* closed [issues](https://github.com/AwesomeAssertions/AwesomeAssertions.DataSets/issues?utf8=%E2%9C%93&q=is%3Aissue), to see if the issue has already been reported?
           * Tried reproducing your problem in a new isolated project?
-          * Read the [documentation](https://fluentassertions.com/introduction)?
-          * Searched the two [test](https://github.com/fluentassertions/fluentassertions/tree/develop/Tests/FluentAssertions.Specs) [suites](https://github.com/fluentassertions/fluentassertions/tree/develop/Tests/FluentAssertions.Equivalency.Specs) if there is a test documenting the expected behavior?
+          * Read the [documentation](https://awesomeassertions.org/introduction)?
+          * Searched the [test suite](https://github.com/AwesomeAssertions/AwesomeAssertions.DataSets/blob/main/Tests/FluentAssertions.DataTests.Specs) if there is a test documenting the expected behavior?
           * Considered if this is a general question and not a bug? For general questions please use [Stack Overflow](https://stackoverflow.com/questions/tagged/fluent-assertions?mixed=1).
   - type: textarea
     id: background
@@ -68,7 +68,7 @@ body:
     attributes:
       label: Regression?
       description: |
-        Did this work in a previous release of Fluent Assertions? If you can try a previous release to find out, that can help us narrow down the problem. If you don't know, that's OK.
+        Did this work in a previous release of Awesome Assertions or Fluent Assertions? If you can try a previous release to find out, that can help us narrow down the problem. If you don't know, that's OK.
       placeholder: Regression?
     validations:
       required: false
@@ -87,7 +87,7 @@ body:
       label: Configuration
       description: |
         Please provide more information on your .NET configuration:
-          * Which version of Fluent Assertions are you using?
+          * Which version of Awesome Assertions are you using?
           * Which .NET runtime and version are you targeting? E.g. .NET framework 4.6.1 or .NET Core 2.1.
       placeholder: Configuration
     validations:

--- a/.github/ISSUE_TEMPLATE/02_api_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/02_api_proposal.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        We welcome API proposals! We have a process to evaluate the value and shape of new API. There is an overview of our process [here](https://github.com/fluentassertions/fluentassertions/blob/develop/CONTRIBUTING.md#contributing-changes). This template will help us gather the information we need to start the review process.
+        We welcome API proposals! We have a process to evaluate the value and shape of new API. There is an overview of our process [here](https://github.com/AwesomeAssertions/AwesomeAssertions.DataSets/blob/main/CONTRIBUTING.md#contributing-changes). This template will help us gather the information we need to start the review process.
   - type: textarea
     id: background
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: 📚 Documentation
-    url: https://fluentassertions.com/introduction/
+    url: https://awesomeassertions.org/introduction/
     about: Read our comprehensive documentation.
-  - name: ⭐ Sponsor Fluent Assertions
-    url: https://github.com/sponsors/fluentassertions
-    about: Help the continued development.
   - name: 💬 Ask on Stack Overflow
     url: https://stackoverflow.com/questions/tagged/fluent-assertions
     about: The best place for asking general purpose questions.
-  - name: 💬 Ask on Slack
-    url: https://fluentassertionsslack.herokuapp.com/
-    about: Get in touch with the whole community.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,5 +5,5 @@
 
 * [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
 * [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
-* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
-* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
+* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in this test](https://github.com/AwesomeAssertions/AwesomeAssertions.DataSets/blob/main/Tests/FluentAssertions.DataSets.Specs/DataSetSpecs.cs#L37).
+* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to Fluent Assertions for DataSets
+# Contributing to Awesome Assertions for DataSets
 
 Few open-source projects are going to be successful without contributions.
-Fluent Assertions for DataSets is no exception and we are deeply grateful for all contributions no matter their size.
+Awesome Assertions for DataSets is no exception and we are deeply grateful for all contributions no matter their size.
 However, to improve that collaboration this document presents a few steps to smoothen the process.
 
 ## Finding Existing Issues
 
-Before filing a new issue, please search our [issues](https://github.com/fluentassertions/fluentassertions.datasets/issues) to check if it already exists.
+Before filing a new issue, please search our [issues](https://github.com/AwesomeAssertions/AwesomeAssertions.datasets/issues) to check if it already exists.
 
 If you do find an existing issue, please include your own feedback in the discussion.
 Instead of posting "me too", upvote the issue with 👍, as this better helps us prioritize popular issues and avoids spamming people subscribing to the issue.
@@ -23,7 +23,7 @@ Ideally, a bug report should contain the following information:
 * Information on the environment: nuget version, .NET version, etc.
 * Additional information, e.g. is it a regression from previous versions? are there any known workarounds?
 
-When ready to submit a bug report, please use the [Bug Report issue template](https://github.com/fluentassertions/fluentassertions.datasets/issues/new?labels=&template=01_bug_report.yml).
+When ready to submit a bug report, please use the [Bug Report issue template](https://github.com/AwesomeAssertions/AwesomeAssertions.datasets/issues/new?labels=&template=01_bug_report.yml).
 
 #### Why are Minimal Reproductions Important?
 
@@ -44,12 +44,12 @@ Stack Overflow has a great article about [how to create a minimal, reproducible 
 
 ## Contributing Changes
 
-Fluent Assertions exposes many extension knobs to write custom assertions or extend over existing assertions.
+Awesome Assertions exposes many extension knobs to write custom assertions or extend over existing assertions.
 As such the core library very rarely takes extra dependencies to provide assertion on someone's favorite library.
-Instead we suggest that you create a dedicated library as we did with [FluentAssertions.Json](https://github.com/fluentassertions/fluentassertions.json).
-See the [documentation](https://fluentassertions.com/extensibility/) for more information about extensibility.
+Instead we suggest that you create a dedicated library as we did with [AwesomeAssertions.Json](https://github.com/AwesomeAssertions/AwesomeAssertions.json).
+See the [documentation](https://awesomeassertions.org/extensibility/) for more information about extensibility.
 
-In order for Fluent Assertions to provide a consistent experience across the library, we generally want to review every single API that is added, changed or deleted.
+In order for Awesome Assertions to provide a consistent experience across the library, we generally want to review every single API that is added, changed or deleted.
 Changes to the API must be proposed, discussed and approved with the `api-approved` label in a separate issue before opening a PR.
 Sometimes the implementation leads to new knowledge such that the approved API must be reevaluated.
 If you're unsure about whether a change fits the library we suggest you open an issue first to avoid wasting your time if the changes does not fit the project.
@@ -58,7 +58,7 @@ Also we balance whether proposed features are too niche or complex to pull their
 A feature proposal so to speak starts at [-100 points](https://web.archive.org/web/20200112182339/https://blogs.msdn.microsoft.com/ericgu/2004/01/12/minus-100-points/) and needs to prove its worth.
 Remember that a rejection of an API approval is not necessarily a rejection of your idea, but merely a rejection of including it in the core library.
 
-When ready to submit a proposal, please use the [API Suggestion issue template](https://github.com/fluentassertions/fluentassertions/issues/new?labels=api-suggestion&template=02_api_proposal.yml&title=%5BAPI+Proposal%5D%3A+).
+When ready to submit a proposal, please use the [API Suggestion issue template](https://github.com/AwesomeAssertions/AwesomeAssertions/issues/new?labels=api-suggestion&template=02_api_proposal.yml&title=%5BAPI+Proposal%5D%3A+).
 
 Contributions must also satisfy the other published guidelines defined in this document.
 
@@ -66,13 +66,11 @@ Contributions must also satisfy the other published guidelines defined in this d
 
 Please do:
 
-* Target the [Pull Request](https://help.github.com/articles/using-pull-requests) at the `develop` branch.
+* Target the [Pull Request](https://help.github.com/articles/using-pull-requests) at the `main` branch.
 * Follow the style presented in the [Coding Guidelines for C#](https://csharpcodingguidelines.com/).
-* Align with the Fluent Assertions [Design Principles](https://github.com/fluentassertions/fluentassertions/issues/1340)
-* Ensure that changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/fluentassertions/fluentassertions/blob/daaf35b9b59b622c96d0c034e8972a020b2bee55/Tests/FluentAssertions.Shared.Specs/BasicEquivalencySpecs.cs#L33).
-  * Also the code coverage reported by the coveralls must be non-decreasing unless accepted by the authors.
-* If the contribution adds a feature or fixes a bug, please update the [**release notes**](https://github.com/fluentassertions/fluentassertions/blob/develop/docs/_pages/releases.md), which is published on the [website](https://fluentassertions.com/releases).
-* If the contribution changes the public API, the changes needs to be included by running [`AcceptApiChanges.ps1`](https://github.com/fluentassertions/fluentassertions/tree/develop/AcceptApiChanges.ps1)/[`AcceptApiChanges.sh`](https://github.com/fluentassertions/fluentassertions/tree/develop/AcceptApiChanges.sh) or using Rider's [Verify Support](https://plugins.jetbrains.com/plugin/17240-verify-support) plug-in.
+* Align with the Awesome Assertions [Design Principles](https://github.com/AwesomeAssertions/AwesomeAssertions/wiki/Design-Guidelines)
+* Ensure that changes are covered by a new or existing set of unit tests which follow the Arrange-Act-Assert syntax such as is used [in this example](https://github.com/AwesomeAssertions/AwesomeAssertions/blob/main/Tests/FluentAssertions.Equivalency.Specs/BasicSpecs.cs#L13).
+* If the contribution changes the public API, the changes needs to be included by running [`AcceptApiChanges.ps1`](https://github.com/AwesomeAssertions/AwesomeAssertions.DataSets/blob/main/AcceptApiChanges.ps1)/[`AcceptApiChanges.sh`](https://github.com/AwesomeAssertions/AwesomeAssertions.DataSets/blob/main/AcceptApiChanges.sh) or using Rider's [Verify Support](https://plugins.jetbrains.com/plugin/17240-verify-support) plug-in.
 
 Please do not:
 


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
