### PR TITLE
chore: Exclude Microsoft.NET.Test.Sdk from updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,10 @@
     "ignorePaths": [
         "Build/**"
     ],
-	"ignoreDeps": ["AwesomeAssertions"],
+	"ignoreDeps": [
+        "AwesomeAssertions",
+        "Microsoft.NET.Test.Sdk"
+    ],
     "packageRules": [
         {
             "matchSourceUrls": [


### PR DESCRIPTION
* Exclude Microsoft.NET.Test.Sdk from updates, because with 17.14.0 support for net6 was dropped

<!-- Please provide a description of your changes above the IMPORTANT checklist -->


## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in this test](https://github.com/AwesomeAssertions/AwesomeAssertions.DataSets/blob/main/Tests/AwesomeAssertions.DataSets.Specs/DataSetSpecs.cs#L37).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/main/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/main/AcceptApiChanges.sh).
